### PR TITLE
Spec: Conformance section points at csvj-org/conformance

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@ The grammar above does not express the cross-line semantic constraints from the 
 <h2>Conformance</h2>
 
 <p>
-An implementation claims CSVJ conformance by accepting every input the specification calls valid and rejecting every input the specification calls invalid. A language-agnostic conformance test suite is planned at <a href="https://github.com/csvj-org">github.com/csvj-org</a>; this section will link to the published vectors once the suite is released.
+An implementation claims CSVJ conformance by accepting every input the specification calls valid and rejecting every input the specification calls invalid. The language-agnostic conformance test suite for CSVJ is published at <a href="https://github.com/csvj-org/conformance">github.com/csvj-org/conformance</a> as accept-set, reject-set, and expected-output vectors that any parser can run regardless of implementation language.
 </p>
 
 


### PR DESCRIPTION
## Summary

Replaces the Conformance-section stub paragraph (added in #3, back when the
suite was still described as planned) with one that names the published
location of the test suite and the three vector sets it ships
(accept-set / reject-set / expected-output).

Per PLAN.md §1 "Conformance section content" — the stub said "this section
will link to the published vectors once the suite is released," and the
suite is now released at <https://github.com/csvj-org/conformance> with an
initial vector set merged in conformance#1 and a second batch in flight
(conformance#2).

This is a normative spec-text change (Conformance section content), so it
lands as `[PR]` per the self-merge policy regardless of how trivial the
diff looks.

## Test plan

- [ ] Render `index.html` locally and confirm the Conformance section now
      reads cleanly and the link resolves to the conformance repo.
- [ ] Confirm no other section references the old "planned" wording.