### PR TITLE
HTML validity sweep: render-identical structural fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 <link rel="canonical" href="https://csvj.org/">
 <link rel="icon" type="image/x-icon" href="favicon.ico">
 
-<style type="text/css">
+<style>
 body { 
 	margin: 40px auto 40px 40px; 
 	max-width: 650px;
@@ -188,7 +188,7 @@ Consider the following table:
 <td>1995</td>
 <td>Jeep</td>
 <td>Grand Cherokee</td>
-<td>SELL NOW!<br />
+<td>SELL NOW!<br>
 air, moon roof, loaded</td>
 <td>$3599</td>
 </tr>
@@ -242,20 +242,19 @@ For the sake of transparency, we recommend specifying that you are exporting CSV
 
 <h2>Libraries and Software</h2>
 
-<p>See <a href="https://github.com/csvj-org">github.com/csvj-org</a> for all code by CSVJ.org. Following libraries are available:
-	<ul>
-		<li>Go<ul>
-			<li><a href="https://github.com/csvj-org/gocsvj">gocsvj</a></li></ul>
-		</li>
-	</ul>
-</p>
+<p>See <a href="https://github.com/csvj-org">github.com/csvj-org</a> for all code by CSVJ.org. Following libraries are available:</p>
+<ul>
+	<li>Go<ul>
+		<li><a href="https://github.com/csvj-org/gocsvj">gocsvj</a></li>
+	</ul></li>
+</ul>
 
 
 <p><b>Looking for volunteers</b>: we want to create CSVJ libraries for different languages including, but not limited to:
  C#, C++, golang, Java, JavaScript, Matlab, Objective-C, PHP, Python, R, rust, Swift.</p>
 
 <p>
-Other languages are welcome too. Email <tt>rcpt at andrian dot io</tt> with <tt>csvj</tt> mentioned in the subject. 
+Other languages are welcome too. Email <code>rcpt at andrian dot io</code> with <code>csvj</code> mentioned in the subject.
 </p>
 
 <p>After libraries are created, we would like the following types software to support CSVJ: RDBMS, spreadsheet editors, statistical software, financial and accounting software, machine learning packages and solutions, user management systems and others.</p>  


### PR DESCRIPTION
## Summary

W3C Nu validator pass against `index.html`. All changes are render-identical structural cleanup; no spec content is touched.

- Drop obsolete `type="text/css"` from `<style>`.
- Fix unmatched `</p>` in the Libraries section: the `<ul>` was invalidly nested inside `<p>`. The intro sentence now closes its own paragraph and the list is a sibling.
- `<br />` → `<br>` in the Example table (self-closing slash is invalid on void elements in HTML5).
- `<tt>` → `<code>` in the volunteer-contact paragraph (`<tt>` is obsolete in HTML5; both already share the same CSS rule, so rendering is unchanged).

## Out of scope (deliberately)

- Missing `alt` text on the three spec diagrams — that's new descriptive *content* next to normative diagrams, not structural HTML cleanup.
- Custom FAQ tags (`<faq>`, `<qq>`, `<aa>`, `<cc>`) — intentional per `CLAUDE.md`; their CSS keys off these names.
- No `<html lang="en">` wrapper — intentional minimal-page style per `CLAUDE.md` ("no `<html>`/`<head>`/`<body>` wrappers").

## Validation

Before: 16 validator errors / 4 warnings.  
After: 14 errors (all in the deliberately-out-of-scope set above) / 1 warning.

## Test plan

- [x] Re-ran W3C Nu validator against the working copy; only the expected unfixable items remain.
- [ ] Eyeball the rendered page (Libraries section + Example table) — content order and formatting unchanged.