### PR TITLE
Add HTML validator CI workflow

### DIFF
--- a/.github/workflows/validate-html.yml
+++ b/.github/workflows/validate-html.yml
@@ -22,6 +22,7 @@ jobs:
           html5validator \
             --root . \
             --match 'index.html' \
-            --ignore-re 'Element .(faq|qq|aa|cc). not allowed' \
-            --ignore-re 'The .(faq|qq|aa|cc). element is a completely-unknown element' \
-            --ignore-re 'An .img. element must have an .alt. attribute'
+            --ignore-re \
+              'Element .(faq|qq|aa|cc). not allowed' \
+              'The .(faq|qq|aa|cc). element is a completely-unknown element' \
+              'An .img. element must have an .alt. attribute'

--- a/.github/workflows/validate-html.yml
+++ b/.github/workflows/validate-html.yml
@@ -1,0 +1,27 @@
+name: Validate HTML
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.x'
+      - run: pip install html5validator
+      - name: Validate index.html
+        run: |
+          html5validator \
+            --root . \
+            --match 'index.html' \
+            --ignore-re 'Element .(faq|qq|aa|cc). not allowed' \
+            --ignore-re 'The .(faq|qq|aa|cc). element is a completely-unknown element' \
+            --ignore-re 'An .img. element must have an .alt. attribute'


### PR DESCRIPTION
## Summary

Adds `.github/workflows/validate-html.yml`. On every push to `master` and every PR
the workflow runs `html5validator` (Python wrapper around the W3C Nu vnu.jar)
against `index.html`.

The validator currently flags 15 errors on master, all of which are intentional and
called out in `website/CLAUDE.md` or the prior validity-sweep PR #7:

- `<faq>` / `<qq>` / `<aa>` / `<cc>` are custom tags styled via the inline `<style>`
  block. They will never be valid HTML5 — they are intentional spec-page idioms.
- The three spec railroad diagrams (`csvj-file.png`, `csvj-line.png`,
  `csvj-value.png`) are missing `alt` text. Adding descriptive alt text is a
  content task (the diagrams *are* the format definition), deferred per PR #7's
  scoping note.

These three classes are filtered via `--ignore-re`. Everything else — the kind of
breakage that PR #3's `</h2` fix and PR #7's `<style type="text/css">` /
`<ul>`-inside-`<p>` fixes addressed — will fail the build.

Third-party actions SHA-pinned with the tag as a trailing comment, matching the
`gocsvj` workflow convention.

## Test plan

- [ ] CI green on this PR (validator passes after filtering)
- [ ] Workflow shows up in the Actions tab