### PR TITLE
Libraries: add jscsvj (JavaScript / TypeScript reference impl)

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,11 +247,14 @@ For the sake of transparency, we recommend specifying that you are exporting CSV
 	<li>Go<ul>
 		<li><a href="https://github.com/csvj-org/gocsvj">gocsvj</a></li>
 	</ul></li>
+	<li>JavaScript / TypeScript<ul>
+		<li><a href="https://github.com/csvj-org/jscsvj">jscsvj</a></li>
+	</ul></li>
 </ul>
 
 
 <p><b>Looking for volunteers</b>: we want to create CSVJ libraries for different languages including, but not limited to:
- C#, C++, golang, Java, JavaScript, Matlab, Objective-C, PHP, Python, R, rust, Swift.</p>
+ C#, C++, Java, Matlab, Objective-C, PHP, Python, R, rust, Swift.</p>
 
 <p>
 Other languages are welcome too. Email <code>rcpt at andrian dot io</code> with <code>csvj</code> mentioned in the subject.


### PR DESCRIPTION
## Summary

- Adds `csvj-org/jscsvj` as the second entry in the Libraries list, mirroring the Go entry's nested-ul layout.
- Prunes `JavaScript` from the volunteer-wanted languages paragraph since it now has a library.
- Also prunes `golang` from that same paragraph — pre-existing duplicate of `Go`, which already had `gocsvj`.

The Libraries list is a normative section per project conventions, so this ships as its own focused PR for spec-author review.

Closes the §3 PLAN.md task "Add `jscsvj` to the Libraries list."

## Test plan

- [ ] Confirm the new `<li>` renders with the same indentation/style as the Go entry.
- [ ] Confirm `https://github.com/csvj-org/jscsvj` resolves.
- [ ] Confirm the HTML validator CI workflow (#8) stays green on the diff.