### PR TITLE
Add phpcsvj to Libraries list

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,11 +255,14 @@ For the sake of transparency, we recommend specifying that you are exporting CSV
 	<li>JavaScript / TypeScript<ul>
 		<li><a href="https://github.com/csvj-org/jscsvj">jscsvj</a></li>
 	</ul></li>
+	<li>PHP<ul>
+		<li><a href="https://github.com/csvj-org/phpcsvj">phpcsvj</a></li>
+	</ul></li>
 </ul>
 
 
 <p><b>Looking for volunteers</b>: we want to create CSVJ libraries for different languages including, but not limited to:
- C#, C++, Java, Matlab, Objective-C, PHP, Python, R, rust, Swift.</p>
+ C#, C++, Java, Matlab, Objective-C, Python, R, rust, Swift.</p>
 
 <p>
 Other languages are welcome too. Email <code>rcpt at andrian dot io</code> with <code>csvj</code> mentioned in the subject.


### PR DESCRIPTION
## Summary

- Add a `PHP → phpcsvj` entry to the Libraries list in `index.html`,
  mirroring the existing Go and JavaScript entries.
- Drop `PHP` from the "Looking for volunteers" paragraph since the
  language is no longer volunteer-wanted.

## Rationale

`csvj-org/phpcsvj`'s reader/writer landed in phpcsvj#2 (merged 2026-05-27)
with strict §1 enforcement from day one and a 45-case PHPUnit suite. The
conformance suite is wired into CI in phpcsvj#3 and all 25 vectors of
`csvj-org/conformance@master` pass on PHP 8.4. The library is ready to be
listed alongside `gocsvj` and `jscsvj`.

This is a normative change to the Libraries section of the spec page,
so it ships as its own focused PR for human review per the §Conventions
rule in `PLAN.md`.

## Test plan

- [ ] Open `index.html` locally; confirm the new PHP entry renders with
      the same nested-`<ul>` layout as Go / JS / TS.
- [ ] Confirm `html5validator` CI passes.