### PR TITLE
Add rscsvj to the Libraries list

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,11 +258,14 @@ For the sake of transparency, we recommend specifying that you are exporting CSV
 	<li>PHP<ul>
 		<li><a href="https://github.com/csvj-org/phpcsvj">phpcsvj</a></li>
 	</ul></li>
+	<li>Rust<ul>
+		<li><a href="https://github.com/csvj-org/rscsvj">rscsvj</a></li>
+	</ul></li>
 </ul>
 
 
 <p><b>Looking for volunteers</b>: we want to create CSVJ libraries for different languages including, but not limited to:
- C#, C++, Java, Matlab, Objective-C, Python, R, rust, Swift.</p>
+ C#, C++, Java, Matlab, Objective-C, Python, R, Swift.</p>
 
 <p>
 Other languages are welcome too. Email <code>rcpt at andrian dot io</code> with <code>csvj</code> mentioned in the subject.


### PR DESCRIPTION
## Summary

- Add a **Rust** entry to the Libraries list (`csvj-org/rscsvj`), mirroring the existing Go / JS / PHP nested-ul layout.
- Prune `rust` from the volunteer-wanted languages paragraph (now that the library exists).

## Rationale

`csvj-org/rscsvj` is feature-complete:

- Strict §1 `parse` + `stringify` (rscsvj#2, merged 2026-05-27)
- 47-case test suite across `tests/parse.rs` + `tests/stringify.rs`
- `csvj-org/conformance@master` wired into CI; all 25 vectors pass (rscsvj#3, merged 2026-05-27)
- MIT / Apache-2.0 dual license per Rust convention; CI matrix over stable + MSRV 1.74

Per PLAN.md §Conventions the Libraries list is normative spec content, so this is held `[PR]` for human review rather than self-merged.

## Test plan

- [ ] Open `index.html` locally; confirm the new `<li>Rust</li>` renders in the expected position and that the volunteer-wanted paragraph no longer mentions `rust`.
- [ ] CI: `html5validator` job stays green (no structural HTML change).