### PR TITLE
Add pycsvj to the Libraries list

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,11 +261,14 @@ For the sake of transparency, we recommend specifying that you are exporting CSV
 	<li>Rust<ul>
 		<li><a href="https://github.com/csvj-org/rscsvj">rscsvj</a></li>
 	</ul></li>
+	<li>Python<ul>
+		<li><a href="https://github.com/csvj-org/pycsvj">pycsvj</a></li>
+	</ul></li>
 </ul>
 
 
 <p><b>Looking for volunteers</b>: we want to create CSVJ libraries for different languages including, but not limited to:
- C#, C++, Java, Matlab, Objective-C, Python, R, Swift.</p>
+ C#, C++, Java, Matlab, Objective-C, R, Swift.</p>
 
 <p>
 Other languages are welcome too. Email <code>rcpt at andrian dot io</code> with <code>csvj</code> mentioned in the subject.


### PR DESCRIPTION
## Summary

- Add a **Python** entry to the Libraries list (`csvj-org/pycsvj`), mirroring the existing Go / JS / PHP / Rust nested-ul layout.
- Prune `Python` from the volunteer-wanted languages paragraph (now that the library exists).

## Rationale

`csvj-org/pycsvj` is feature-complete:

- Strict §1 `csvj.parse` + `csvj.stringify` (pycsvj#1, merged 2026-05-27)
- 50-case pytest suite ported from phpcsvj's layout
- `csvj-org/conformance@master` wired into CI; all 25 vectors pass (pycsvj#2, merged 2026-05-27)
- MIT license; CI matrix over Python 3.10 / 3.11 / 3.12 / 3.13

Per PLAN.md §Conventions the Libraries list is normative spec content, so this is held `[PR]` for human review rather than self-merged.

## Test plan

- [ ] Open `index.html` locally; confirm the new `<li>Python</li>` renders in the expected position and that the volunteer-wanted paragraph no longer mentions `Python`.
- [ ] CI: `html5validator` job stays green (no structural HTML change).